### PR TITLE
match the "request" key exactly

### DIFF
--- a/plugins/parsers/nginx.py
+++ b/plugins/parsers/nginx.py
@@ -8,7 +8,7 @@ def parse_nginx(line):
         for k, v in r.groupdict().iteritems():
             if v is None or v is "-":
                 continue
-            if "request" in k:
+            if k == "request":
                 if "?" in v:
                     request = v.partition("?")
                     path = request[0]


### PR DESCRIPTION
Variable `k` is a string (representing a key in a dict), not the dictionary itself.  Therefore, we should be testing for equality.  If we do not, we may incorrectly match on any key that contains the string "request" within it (e.g. requesting_user).
